### PR TITLE
Fixed bug with names displayed in "usage" entries in locust output

### DIFF
--- a/locust/cli.py
+++ b/locust/cli.py
@@ -2,10 +2,7 @@
 The Locust CLI
 """
 import argparse
-import json
-import os
 import sys
-from typing import Any, Dict, Optional
 
 from . import git
 from . import parse
@@ -17,6 +14,13 @@ def generate_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Locust: Analyze Python code across git references",
         epilog=f"Version {version.LOCUST_VERSION}",
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"locust {version.LOCUST_VERSION}",
+        help="Print the locust version",
     )
     git.populate_argument_parser(parser)
     parse.populate_argument_parser(parser)

--- a/locust/parse.py
+++ b/locust/parse.py
@@ -210,6 +210,15 @@ class LocustVisitor(ast.NodeVisitor):
             qualifications = symbols.get(cumulative_component)
             if qualifications:
                 for qualification in qualifications:
+                    origin_definition = RawDefinition(
+                        name=qualification,
+                        change_type=self.context_type.value,
+                        line=node.lineno,
+                        offset=node.col_offset,
+                        end_line=node.end_lineno,
+                        end_offset=node.end_col_offset,
+                        parent=parent,
+                    )
                     # Replace prefix with qualification in final_component
                     name = final_component.replace(
                         cumulative_component, qualification, 1
@@ -223,7 +232,8 @@ class LocustVisitor(ast.NodeVisitor):
                         end_offset=node.end_col_offset,
                         parent=parent,
                     )
-                    self.definitions.append(definition)
+
+                    self.definitions.extend([origin_definition ,definition])
 
     def reset(self):
         self.scope = []

--- a/locust/parse.py
+++ b/locust/parse.py
@@ -233,7 +233,7 @@ class LocustVisitor(ast.NodeVisitor):
                         parent=parent,
                     )
 
-                    self.definitions.extend([origin_definition ,definition])
+                    self.definitions.extend([origin_definition, definition])
 
     def reset(self):
         self.scope = []

--- a/locust/parse.py
+++ b/locust/parse.py
@@ -205,12 +205,17 @@ class LocustVisitor(ast.NodeVisitor):
         ]
         symbols = self._current_symbols()
         parent = self._current_scope_parent()
+        final_component = cumulative_components[-1]
         for cumulative_component in cumulative_components:
             qualifications = symbols.get(cumulative_component)
             if qualifications:
                 for qualification in qualifications:
+                    # Replace prefix with qualification in final_component
+                    name = final_component.replace(
+                        cumulative_component, qualification, 1
+                    )
                     definition = RawDefinition(
-                        name=qualification,
+                        name=name,
                         change_type=self.context_type.value,
                         line=node.lineno,
                         offset=node.col_offset,

--- a/locust/version.py
+++ b/locust/version.py
@@ -1,4 +1,4 @@
-LOCUST_VERSION = "0.3.1"
+LOCUST_VERSION = "0.3.2"
 
 
 def main():

--- a/test.sh
+++ b/test.sh
@@ -15,4 +15,6 @@ then
 	exit 1
 fi
 
-python -m unittest discover -v
+TEST_COMMAND=${@:-"discover -v"}
+
+python -m unittest $TEST_COMMAND

--- a/tests/fixtures/test_parse.json
+++ b/tests/fixtures/test_parse.json
@@ -127,7 +127,7 @@
       "parent": {}
     },
     {
-      "name": "argparse",
+      "name": "argparse.ArgumentParser",
       "change_type": "usage",
       "filepath": "sample.py",
       "revision": "0838585",

--- a/tests/fixtures/test_parse.json
+++ b/tests/fixtures/test_parse.json
@@ -127,6 +127,16 @@
       "parent": {}
     },
     {
+      "name": "argparse",
+      "change_type": "usage",
+      "filepath": "sample.py",
+      "revision": "0838585",
+      "line": 7,
+      "changed_lines": 1,
+      "total_lines": 1,
+      "parent": {}
+    },
+    {
       "name": "argparse.ArgumentParser",
       "change_type": "usage",
       "filepath": "sample.py",

--- a/tests/fixtures/test_parse_dependencies.json
+++ b/tests/fixtures/test_parse_dependencies.json
@@ -312,6 +312,16 @@
       "parent": {}
     },
     {
+      "name": "json",
+      "change_type": "usage",
+      "filepath": "mod/submod/print.py",
+      "revision": "04cec01",
+      "line": 5,
+      "changed_lines": 1,
+      "total_lines": 1,
+      "parent": {}
+    },
+    {
       "name": "json.dumps",
       "change_type": "usage",
       "filepath": "mod/submod/print.py",

--- a/tests/fixtures/test_parse_dependencies.json
+++ b/tests/fixtures/test_parse_dependencies.json
@@ -312,7 +312,7 @@
       "parent": {}
     },
     {
-      "name": "json",
+      "name": "json.dumps",
       "change_type": "usage",
       "filepath": "mod/submod/print.py",
       "revision": "04cec01",

--- a/tests/fixtures/test_render.json
+++ b/tests/fixtures/test_render.json
@@ -20,6 +20,14 @@
           "children": []
         },
         {
+          "name": "argparse",
+          "type": "usage",
+          "line": 7,
+          "changed_lines": 1,
+          "total_lines": 1,
+          "children": []
+        },
+        {
           "name": "argparse.ArgumentParser",
           "type": "usage",
           "line": 7,

--- a/tests/fixtures/test_render.json
+++ b/tests/fixtures/test_render.json
@@ -20,7 +20,7 @@
           "children": []
         },
         {
-          "name": "argparse",
+          "name": "argparse.ArgumentParser",
           "type": "usage",
           "line": 7,
           "changed_lines": 1,


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

The Python analyzer for `locust` was incorrectly generating `usage` entries.

For example, if we did `import argparse` and used `argparse.ArgumentParser`, it would show a usage of `argparse` but not `argparse.ArgumentParser`.

This PR adds both usages to the output.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

```
LOCUST_TESTCASES_DIR=<path to local copy of test cases dir> ./test.sh
```

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
